### PR TITLE
Add more explosives and destruction for rifle and shotgun

### DIFF
--- a/grenade_launchers_config.txt
+++ b/grenade_launchers_config.txt
@@ -171,6 +171,7 @@
     "nade_launcher_extra_destruction_size" : 2,
     "nade_launcher_extra_destruction_sound" : 2,
     "nade_launcher_extra_destruction_weapons" : ["rifle", "shotgun"],
+    "nade_launcher_extra_destruction_sound_weapons" : ["rifle", "shotgun"],
     "mini_tc_scale_x" : 1.5,
     "mini_tc_scale_y" : 1.5
 }

--- a/grenade_launchers_config.txt
+++ b/grenade_launchers_config.txt
@@ -166,6 +166,8 @@
     "medkit_heal_amount" : 40,
     "nade_launcher_restore_blocks" : false,
     "nade_launcher_restore_blocks_grayscale" : false,
+    "nade_launcher_extra_destruction" : true,
+    "nade_launcher_extra_destruction_size" : 2,
     "mini_tc_scale_x" : 1.5,
     "mini_tc_scale_y" : 1.5
 }

--- a/grenade_launchers_config.txt
+++ b/grenade_launchers_config.txt
@@ -166,6 +166,7 @@
     "medkit_heal_amount" : 40,
     "nade_launcher_restore_blocks" : false,
     "nade_launcher_restore_blocks_grayscale" : false,
+    "nade_launcher_restore_blocks_size": 5,
     "nade_launcher_extra_destruction" : true,
     "nade_launcher_extra_destruction_size" : 2,
     "nade_launcher_extra_destruction_sound" : 2,

--- a/grenade_launchers_config.txt
+++ b/grenade_launchers_config.txt
@@ -168,6 +168,8 @@
     "nade_launcher_restore_blocks_grayscale" : false,
     "nade_launcher_extra_destruction" : true,
     "nade_launcher_extra_destruction_size" : 2,
+    "nade_launcher_extra_destruction_sound" : 2,
+    "nade_launcher_extra_destruction_weapons" : ["rifle", "shotgun"],
     "mini_tc_scale_x" : 1.5,
     "mini_tc_scale_y" : 1.5
 }

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -247,13 +247,16 @@ def apply_script(protocol, connection, config):
             if position.z >= 1:
                 position.z -= extra_height
 
-            # Increase destruction area for Rifle
-            if config.get('nade_launcher_extra_destruction', False):
-                if self.is_enabled_extra_destrution_for_grenade(grenade.name):
-                    # Default is 2x2x2
-                    # TODO: allow to set destruction size per weapon type
-                    grid_size = config.get('nade_launcher_extra_destruction_size', 2)
-                    self.create_grenade_grid(position, grid_size, grenade, extra_height)
+            try:
+                # TODO: allow to set destruction size per weapon type
+                # Increase destruction area
+                if config.get('nade_launcher_extra_destruction', False):
+                    if self.is_enabled_extra_destrution_for_grenade(grenade.name):
+                        # Default is 2x2x2
+                        grid_size = config.get('nade_launcher_extra_destruction_size', 2)
+                        self.create_grenade_grid(position, grid_size, grenade, extra_height)
+            except Exception as ex:
+                print("Got some exception when increasing destruction area", ex)
 
             connection.grenade_exploded(self, grenade)
 
@@ -282,6 +285,9 @@ def apply_script(protocol, connection, config):
 
                         # Spawn extra grenades on server side only
                         _ = self.create_grenade(origin_position, zero_vector, self.grenade_exploded, "no_damage_grenade")
+
+            if self.world_object is None:
+                return
 
             extra_destruction_sound = config.get('nade_launcher_extra_destruction_sound', 2)
             if extra_destruction_sound <= 0:

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -284,9 +284,14 @@ def apply_script(protocol, connection, config):
                         # Spawn extra grenades on server side only
                         _ = self.create_grenade(origin_position, zero_vector, self.grenade_exploded, "no_damage_grenade")
 
+            # TODO: ensure performance is not getting worse because of this
+            explosion_distance = distance_3d_vector(self.world_object.position, position)
+            if explosion_distance < 10:
+                # Don't spawn extra grenades for shooter on client side if detonated too close (to avoid extra water slash effects, etc)
+                return
+
             # Create extra explosions at origin point on client side for better visual/audio feedback
             for _ in range(0,3):
-                # TODO: maybe don't spawn extra nades if exploded too close, to avoid water splash and other effects (though keep performance in mind)
                 self.send_grenade_packet(0, 31, position, zero_vector)
 
         def create_grenade(self, position, velocity, grenade_callback, name, fuse = 0.0):

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -340,8 +340,8 @@ def apply_script(protocol, connection, config):
             return 
         
         def rollback_area(self, position):
-            # Hardcoded size
-            size = 5 
+            size = config.get('nade_launcher_restore_blocks_size', 5)
+
             start_point = position.copy() 
             start_point.x -= 2
             start_point.y -= 2

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -29,13 +29,8 @@ G_SMG_LAUNCHER_DAMAGE=15.0
 global G_SHOTGUN_LAUNCHER_DAMAGE
 G_SHOTGUN_LAUNCHER_DAMAGE=50.0
 
-global G_RIFLE_GRENADE_NAME
 G_RIFLE_GRENADE_NAME="rifle_underslung"
-
-global G_SHOTGUN_GRENADE_NAME
 G_SHOTGUN_GRENADE_NAME="shotgun_underslung"
-
-global G_SMG_GRENADE_NAME
 G_SMG_GRENADE_NAME="smg_underslung"
 
 def set_weapon_launcher_damage(connection, value = None, damage_ordinal = 0, launcher_type = "Unknown"):
@@ -254,16 +249,14 @@ def apply_script(protocol, connection, config):
 
             # Increase destruction area for Rifle
             if config.get('nade_launcher_extra_destruction', False):
-                enabled_weapons = config.get('nade_launcher_extra_destruction_weapons', ["rifle", "shotgun"])
-
-                if self.is_enabled_extra_destrution_for_grenade(grenade.name, enabled_weapons):
+                if self.is_enabled_extra_destrution_for_grenade(grenade.name):
                     # Default is 2x2x2
                     grid_size = config.get('nade_launcher_extra_destruction_size', 2)
-                    self.create_grenade_grid(position, grid_size, False, extra_height)
+                    self.create_grenade_grid(position, grid_size, grenade, extra_height)
 
             connection.grenade_exploded(self, grenade)
 
-        def create_grenade_grid(self, position, grid_size, send_to_client = False, extra_height = 0):
+        def create_grenade_grid(self, position, grid_size, original_grenade, extra_height = 0):
             zero_vector = Vertex3(0, 0, 0)
             grenade_impact_size = 3.0
 
@@ -291,6 +284,9 @@ def apply_script(protocol, connection, config):
 
             extra_destruction_sound = config.get('nade_launcher_extra_destruction_sound', 2)
             if extra_destruction_sound <= 0:
+                return
+
+            if not self.is_enabled_extra_destrution_sound_for_grenade(original_grenade.name):
                 return
 
             explosion_distance = distance_3d_vector(self.world_object.position, position)
@@ -399,7 +395,15 @@ def apply_script(protocol, connection, config):
 
             return connection.on_block_destroy(self, x, y, z, mode)
 
-        def is_enabled_extra_destrution_for_grenade(self, grenade_name, enabled_weapons):
+        def is_enabled_extra_destrution_for_grenade(self, grenade_name):
+            enabled_weapons = config.get('nade_launcher_extra_destruction_weapons', ["rifle", "shotgun"])
+            return self.is_enabled_extra_destrution_setting_for_grenade(grenade_name, enabled_weapons)
+
+        def is_enabled_extra_destrution_sound_for_grenade(self, grenade_name):
+            enabled_weapons = config.get('nade_launcher_extra_destruction_sound_weapons', ["rifle", "shotgun"])
+            return self.is_enabled_extra_destrution_setting_for_grenade(grenade_name, enabled_weapons)
+ 
+        def is_enabled_extra_destrution_setting_for_grenade(self, grenade_name, enabled_weapons):
             # Refactoring would be nice
             if "rifle" in enabled_weapons and grenade_name == G_RIFLE_GRENADE_NAME:
                 return True

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -289,12 +289,12 @@ def apply_script(protocol, connection, config):
                         # Spawn extra grenades on server side only
                         _ = self.create_grenade(origin_position, zero_vector, self.grenade_exploded, "no_damage_grenade")
 
-            extra_destruction_sound = config.get('nade_launcher_extra_destruction_sound', 3)
+            extra_destruction_sound = config.get('nade_launcher_extra_destruction_sound', 2)
             if extra_destruction_sound <= 0:
                 return
 
             explosion_distance = distance_3d_vector(self.world_object.position, position)
-            if explosion_distance < 10:
+            if explosion_distance < 20:
                 # Don't spawn extra grenades for shooter on client side if detonated too close (to avoid extra water slash effects, etc)
                 return
 

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -284,7 +284,6 @@ def apply_script(protocol, connection, config):
                         # Spawn extra grenades on server side only
                         _ = self.create_grenade(origin_position, zero_vector, self.grenade_exploded, "no_damage_grenade")
 
-            # TODO: ensure performance is not getting worse because of this
             explosion_distance = distance_3d_vector(self.world_object.position, position)
             if explosion_distance < 10:
                 # Don't spawn extra grenades for shooter on client side if detonated too close (to avoid extra water slash effects, etc)

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -281,6 +281,8 @@ def apply_script(protocol, connection, config):
                         extra_grenade = self.create_grenade(origin_position, zero_vector, self.grenade_exploded, "no_damage_grenade")
                         
                         # TODO: send every 2nd grenade explosion
+                        # TODO: just spawn 2-4 grenades in origin point, creates big boom yet no weird nades in air
+                        # TODO: also, maybe don't spawn extra nades if exploded too close, to avoid water and other effects (though keep performance in mind)
                         if (dx + dy + dz) % 2 == 0:
                             self.send_grenade_packet(extra_grenade.fuse, 31, extra_grenade.position, extra_grenade.velocity)
 

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -250,7 +250,7 @@ def apply_script(protocol, connection, config):
                 position.z -= extra_height
             
             # Increase destruction area for Rifle
-            if config.get('nade_launcher_extra_destruction', False) 
+            if config.get('nade_launcher_extra_destruction', False):
                 if grenade.name == G_RIFLE_GRENADE_NAME or grenade.name == G_SHOTGUN_GRENADE_NAME:
                     # Default is 2x2x2
                     grid_size = config.get('nade_launcher_extra_destruction_size', 2)

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -32,6 +32,9 @@ G_SHOTGUN_LAUNCHER_DAMAGE=50.0
 global G_RIFLE_GRENADE_NAME
 G_RIFLE_GRENADE_NAME="rifle_underslung"
 
+global G_SHOTGUN_GRENADE_NAME
+G_SHOTGUN_GRENADE_NAME="shotgun_underslung"
+
 def set_weapon_launcher_damage(connection, value = None, damage_ordinal = 0, launcher_type = "Unknown"):
     global G_RIFLE_LAUNCHER_DAMAGE
     global G_SMG_LAUNCHER_DAMAGE
@@ -211,7 +214,7 @@ def apply_script(protocol, connection, config):
                 grenade_name = G_RIFLE_GRENADE_NAME
             elif self.weapon is SHOTGUN_WEAPON:
                 multipler = 2.2
-                grenade_name = "shotgun_underslung"
+                grenade_name = G_SHOTGUN_GRENADE_NAME
 
             velocity.x *= multipler
             velocity.y *= multipler
@@ -242,18 +245,16 @@ def apply_script(protocol, connection, config):
             self.penetrate_blocks(grenade, 2)
             
             # Explode a bit higher to not damage ground too much on indirect impact
+            extra_height = 1
             if position.z >= 1:
-                position.z -= 1
+                position.z -= extra_height
             
-            # TODO: read big explosion bool from config
-            # TODO: allow other weapons to be togglable with own explosion size
-            # TODO: what about shotgun rn?
-
             # Increase destruction area for Rifle
-            if grenade.name == G_RIFLE_GRENADE_NAME:
-                # TODO: read size from config
-                grid_size = 2 # 2x2x2
-                self.create_grenade_grid(position, grid_size, False, 1)
+            if config.get('nade_launcher_extra_destruction', False) 
+                if grenade.name == G_RIFLE_GRENADE_NAME or grenade.name == G_SHOTGUN_GRENADE_NAME:
+                    # Default is 2x2x2
+                    grid_size = config.get('nade_launcher_extra_destruction_size', 2)
+                    self.create_grenade_grid(position, grid_size, False, extra_height)
 
             connection.grenade_exploded(self, grenade)
 
@@ -311,7 +312,6 @@ def apply_script(protocol, connection, config):
 
             return False
         
-        # TODO: use this for nade_exploded as well
         def penetrate_blocks(self, grenade, depth = 2):
             position, velocity = grenade.position, grenade.velocity
             velocity.normalize()

--- a/scripts/grenade_launchers.py
+++ b/scripts/grenade_launchers.py
@@ -251,6 +251,7 @@ def apply_script(protocol, connection, config):
             if config.get('nade_launcher_extra_destruction', False):
                 if self.is_enabled_extra_destrution_for_grenade(grenade.name):
                     # Default is 2x2x2
+                    # TODO: allow to set destruction size per weapon type
                     grid_size = config.get('nade_launcher_extra_destruction_size', 2)
                     self.create_grenade_grid(position, grid_size, grenade, extra_height)
 


### PR DESCRIPTION
Make rifle and shotgun destroy 6x6x6 area instead of 3x3x3. 
Spawn 2 grenades on client side for better feedback (more damage = more boom).
But deal the same damage, and only original grenade (and its area) deals damage (to avoid possible intersection of multiple grenade blasts).
Make this configurable (partially) via config.

Also, make block restoration area size configurable as well.